### PR TITLE
install the templates and extra static files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include    ckanext/hierarchy/public     *
+recursive-include    ckanext/hierarchy/templates  *


### PR DESCRIPTION
When installing via pip, the templates and static files were not installed into the python environment. This commit addresses that.