### PR TITLE
ckanext-scheming compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Templates (hierarchy_display plugin):
 * /organization - now shows the organization hierarchy instead of list
 * /organization/about/{id} - now also shows the relevant part of the hierarchy
 
+Snippets (used by hierarchy_display and ckanext-scheming):
+* /scheming/form_snippets/org_hierarchy.html
+
 You can use this extension with CKAN as it is, enabling both plugins. Or if you
 use an extension to customise the form already with an IGroupForm, then you
 will want to only use the hierarchy_display plugin, and copy bits of the
@@ -21,12 +24,26 @@ hierarchy_form into your own. If you have your own templates then you can use
 the snippets (or logic functions) that this extension provides to display the
 trees.
 
+In order to make hierarchy works with ckanext-scheming you need to enable just
+hierarchy_display and then use corresponding form_snippet in your org_schema.
+For example, you may add next field:
+```
+{
+    "field_name": "not_used",
+    "label": "Parent organization",
+    "display_snippet": null,
+    "form_snippet": "org_hierarchy.html",
+    "validators": "ignore_missing"
+}
+```
+
+
 TODO:
 * make the trees prettier with JSTree
 
 ## Compatibility
 
-This extension requires CKAN v2.2 or later. Specifically it uses these changes CKAN: https://github.com/ckan/ckan/pull/1247/files 
+This extension requires CKAN v2.2 or later. Specifically it uses these changes CKAN: https://github.com/ckan/ckan/pull/1247/files
 
 ## Installation
 
@@ -36,7 +53,7 @@ $ . /usr/lib/ckan/default/bin/activate
 (pyenv) $ cd /usr/lib/ckan/default/src
 (pyenv) $ pip install -e "git+https://github.com/datagovuk/ckanext-hierarchy.git#egg=ckanext-hierarchy"
 ```
-Then change your CKAN ini file (e.g. development.ini or production.ini).  Note that hierarchy_display 
+Then change your CKAN ini file (e.g. development.ini or production.ini).  Note that hierarchy_display
 should come before hierarchy_form
 ```
 ckan.plugins = stats text_view recline_view ... hierarchy_display hierarchy_form

--- a/ckanext/hierarchy/helpers.py
+++ b/ckanext/hierarchy/helpers.py
@@ -1,5 +1,5 @@
 import ckan.plugins as p
-
+import ckan.model as model
 
 def group_tree(type_='organization'):
     return p.toolkit.get_action('group_tree')({}, {'type': type_})
@@ -8,3 +8,14 @@ def group_tree(type_='organization'):
 def group_tree_section(id_, type_='organization'):
     return p.toolkit.get_action('group_tree_section')(
         {}, {'id': id_, 'type': type_})
+
+
+def get_allowable_parent_groups(group_id):
+    if group_id:
+        group = model.Group.get(group_id)
+        allowable_parent_groups = \
+            group.groups_allowed_to_be_its_parent(type='organization')
+    else:
+        allowable_parent_groups = model.Group.all(
+            group_type='organization')
+    return allowable_parent_groups

--- a/ckanext/hierarchy/plugin.py
+++ b/ckanext/hierarchy/plugin.py
@@ -31,6 +31,7 @@ class HierarchyDisplay(p.SingletonPlugin):
     def get_helpers(self):
         return {'group_tree': helpers.group_tree,
                 'group_tree_section': helpers.group_tree_section,
+                'get_allowable_parent_groups': helpers.get_allowable_parent_groups,
                 }
 
 
@@ -48,12 +49,5 @@ class HierarchyForm(p.SingletonPlugin, DefaultOrganizationForm):
 
     def setup_template_variables(self, context, data_dict):
         from pylons import tmpl_context as c
-        model = context['model']
         group_id = data_dict.get('id')
-        if group_id:
-            group = model.Group.get(group_id)
-            c.allowable_parent_groups = \
-                group.groups_allowed_to_be_its_parent(type='organization')
-        else:
-            c.allowable_parent_groups = model.Group.all(
-                                                group_type='organization')
+        c.allowable_parent_groups = helpers.get_allowable_parent_groups(group_id)

--- a/ckanext/hierarchy/templates/organization/snippets/organization_form.html
+++ b/ckanext/hierarchy/templates/organization/snippets/organization_form.html
@@ -3,17 +3,5 @@
 {% block basic_fields %}
   {{ super() }}
 
-  <div class="control-group">
-    <label class="control-label" for="field-parent">{{ _("Parent") }}</label>
-    <div class="controls">   
-      <select id="field-parent" name="groups__0__name" data-module="autocomplete">
-        {% set selected_parent = (data.get('groups') or [{'name': ''}])[0]['name'] %} {{ selected_parent }}
-      <option value="" {% if not selected_parent %} selected="selected" {% endif %}>{{ _('None - top level') }}</option>
-      {% for group in c.allowable_parent_groups %}
-        <option value="{{ group.name }}" {% if group.name == selected_parent %}selected="selected"{% endif %}>{{ group.title }}</option>
-      {% endfor %}
-      </select>
-    </div>
-  </div>
-
+  {% snippet 'scheming/form_snippets/org_hierarchy.html', data=data %}
 {% endblock %}

--- a/ckanext/hierarchy/templates/scheming/form_snippets/org_hierarchy.html
+++ b/ckanext/hierarchy/templates/scheming/form_snippets/org_hierarchy.html
@@ -1,0 +1,12 @@
+<div class="control-group">
+  <label class="control-label" for="field-parent">{{ _("Parent") }}</label>
+  <div class="controls">
+    <select id="field-parent" name="groups__0__name" data-module="autocomplete">
+      {% set selected_parent = (data.get('groups') or [{'name': ''}])[0]['name'] %} {{ selected_parent }}
+      <option value="" {% if not selected_parent %} selected="selected" {% endif %}>{{ _('None - top level') }}</option>
+      {% for group in c.allowable_parent_groups or h.get_allowable_parent_groups(data.id) %}
+        <option value="{{ group.name }}" {% if group.name == selected_parent %}selected="selected"{% endif %}>{{ group.title }}</option>
+      {% endfor %}
+    </select>
+  </div>
+</div>


### PR DESCRIPTION
`parent-group` select box moved to separate snippet, that can be directly used
from ckanext-scheming schema. Allowable parent organisations obtained from
helper instead of previous implementation when `setup_template_variables` was
used. Thus, hierarchy_form just can be disabled