### PR TITLE
Fixed bug and minor changes

### DIFF
--- a/ckanext/hierarchy/plugin.py
+++ b/ckanext/hierarchy/plugin.py
@@ -113,9 +113,9 @@ class HierarchyDisplay(p.SingletonPlugin):
                 base_query += [item]
         if c.include_children_selected:
             # add all the children organizations in an 'or' join
-            search_params['q'] = " ".join(base_query)
             children = _children_name_list(helpers.group_tree_section(c.group_dict.get('id'), include_parents=False, include_siblings=False).get('children',[]))
             if(children):
+                search_params['q'] = " ".join(base_query)
                 if (len(search_params['q'].strip())>0):
                     search_params['q'] += ' AND '
                 search_params['q'] += '(organization:%s' % c.group_dict.get('name')
@@ -123,7 +123,7 @@ class HierarchyDisplay(p.SingletonPlugin):
                     if name:
                         search_params['q'] += ' OR organization:%s' %  name
                 search_params['q'] += ")"
-            # add it back to fields 
+            # add it back to fields
             c.fields += [('include_children','True')]
 
         return search_params

--- a/ckanext/hierarchy/templates/scheming/form_snippets/hierarchy_image_url.html
+++ b/ckanext/hierarchy/templates/scheming/form_snippets/hierarchy_image_url.html
@@ -1,0 +1,7 @@
+{% import 'macros/form.html' as form %}
+
+{% set is_upload = data.image_url and not data.image_url.startswith('http') %}
+{% set is_url = data.image_url and data.image_url.startswith('http') %}
+
+{{ form.image_upload(data, errors, is_upload_enabled=h.uploads_enabled(), is_url=is_url, is_upload=is_upload) }}
+

--- a/ckanext/hierarchy/templates/scheming/organization/about.html
+++ b/ckanext/hierarchy/templates/scheming/organization/about.html
@@ -14,8 +14,12 @@
   <dl>
     {% for f in c.scheming_fields %}
       {% if f.display_snippet != None %}
-         <dt>{{ h.scheming_language_text(f.label) }}:</dt>
-         <dd>{{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}</dd>
+        {% if f.field_name == "description" %}
+          {{ h.render_markdown(c.group_dict[f.field_name]) or ("&nbsp;"|safe) }}
+        {% else %}
+          <dt>{{ h.scheming_language_text(f.label) }}:</dt>
+          <dd>{{ c.group_dict[f.field_name] or ("&nbsp;"|safe) }}</dd>
+        {% endif %}
       {% endif %}
     {% endfor %}
   </dl>  


### PR DESCRIPTION
I just found that when searching in an organization without children, the query was sent without any parameter, all datasets from any organization were retrieved.